### PR TITLE
functionalSum.cpp: compile fix for collections like std::vector

### DIFF
--- a/Chapter01/functionalSum.cpp
+++ b/Chapter01/functionalSum.cpp
@@ -22,7 +22,7 @@ const bool isOdd(const int& value){
     return value %2 != 0;
 }
 
-template<typename T, template<class> class CollectionType>
+template<typename T, template<class...> class CollectionType>
 const T sum(const CollectionType<T>& input, const T& init = 0){
     return accumulate(input.begin(), input.end(), init);
 }


### PR DESCRIPTION
The code as it was wouldn't compile for me.

Collections like std::vector take two template arguments and not one.  
Switched template to be a parameter pack.